### PR TITLE
Use http instead.

### DIFF
--- a/arduinoIDE/package_engimusing_modules_index.json
+++ b/arduinoIDE/package_engimusing_modules_index.json
@@ -12,7 +12,7 @@
 			"architecture": "cortex-m0plus",
 			"version": "1.0.1",
 			"category": "Contributed",
-			"url": "https://engimusing.github.io/arduinoIDE/efm48_1/cortex-m0plus-1.0.1.tar.bz2",
+			"url": "http://engimusing.github.io/arduinoIDE/efm48_1/cortex-m0plus-1.0.1.tar.bz2",
 			"archiveFileName": "cortex-m0plus-1.0.1.tar.bz2",
 			"checksum": "SHA-256:d1e4a959395d73260ef4f815fea67e86a45c691d1b73f483d633403c937c0147",
 			"size": "99193",


### PR DESCRIPTION
http is simpler and does not mess up with the network where ssl certificates is needed.

fixes following error for me on linux on a network where custom ssl certificate is needed though
Error downloading https://engimusing.github.io/arduinoIDE/efm48_1/cortex-m0plus-1.0.1.tar.bz2
java.lang.RuntimeException: java.lang.Exception: Error downloading https://engimusing.github.io/arduinoIDE/efm48_1/cortex-m0plus-1.0.1.tar.bz2
    at cc.arduino.contributions.packages.ui.ContributionManagerUI.lambda$onInstallPressed$20(ContributionManagerUI.java:176)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Exception: Error downloading https://engimusing.github.io/arduinoIDE/efm48_1/cortex-m0plus-1.0.1.tar.bz2
    at cc.arduino.contributions.DownloadableContributionsDownloader.download(DownloadableContributionsDownloader.java:113)
    at cc.arduino.contributions.DownloadableContributionsDownloader.download(DownloadableContributionsDownloader.java:67)
    at cc.arduino.contributions.packages.ContributionInstaller.install(ContributionInstaller.java:103)
    at cc.arduino.contributions.packages.ui.ContributionManagerUI.lambda$onInstallPressed$20(ContributionManagerUI.java:173)
